### PR TITLE
docs: add CI and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cchooked - Claude Code Hooks Engine
 
+![CI](https://github.com/1gy/cchooked/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/github/license/1gy/cchooked)
 [![GitHub](https://img.shields.io/badge/GitHub-1gy%2Fcchooked-blue?logo=github)](https://github.com/1gy/cchooked)
 
 Claude Code の hooks 機能向けルールベースエンジン。TOML 設定ファイルで宣言的にルールを定義し、コマンドのブロック、変換、ログ記録などを行います。


### PR DESCRIPTION
## Summary
- Add CI status badge showing build/test status
- Add license badge showing MIT license

## Changes
- `README.md`: Add badges after title