### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "cchooked"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchooked"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Claude Code Hooks Engine - Rule-based hook processor"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0 for release

## Test plan
- Verify Cargo.toml version is updated
- Verify Cargo.lock is updated