### PR TITLE
docs: add release version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cchooked - Claude Code Hooks Engine
 
 ![CI](https://github.com/1gy/cchooked/actions/workflows/ci.yml/badge.svg)
+![Release](https://img.shields.io/github/v/release/1gy/cchooked)
 ![License](https://img.shields.io/github/license/1gy/cchooked)
 [![GitHub](https://img.shields.io/badge/GitHub-1gy%2Fcchooked-blue?logo=github)](https://github.com/1gy/cchooked)
 


### PR DESCRIPTION
## Summary
- READMEにリリースバージョンのバッジを追加

## Changes
- 既存のバッジ（CI, License, GitHub）の並びにReleaseバッジを追加
- shields.ioのGitHub releaseバッジを使用

## Test plan
- バッジがREADME上で正しく表示されることを確認