### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchooked"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Claude Code Hooks Engine - Rule-based hook processor"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump version to 0.3.0 for release.

## Changes in v0.3.0

- Add `working_dir` option for run action (#8)
- Add `${file_dir}` template variable
- Add `${workspace_root}` template variable

## Checklist

- [x] Version bumped in Cargo.toml
- [ ] Merge #9 before this PR