### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "cchooked"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchooked"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Claude Code Hooks Engine - Rule-based hook processor"
 license = "MIT"


### PR DESCRIPTION
## Summary
- test: use serial_test crate for env var tests
- chore: bump version to 0.4.0

## Changes
- Added `serial_test` crate for proper test isolation
- Applied `#[serial]` attribute to env var tests
- Bumped version to 0.4.0