### PR TITLE
fix: Allow log actions to continue rule evaluation

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@ use crate::rule::HookInput;
 use std::process::Command;
 
 /// Execution context containing extracted input values and environment information.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Context {
     /// Command string from tool input.
     pub command: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,18 @@ fn run() -> error::Result<output::Output> {
     let rules = rule::compile_rules(&config)?;
 
     match rule::evaluate_rules(&rules, &event, &input) {
-        Some((match_result, context)) => {
-            Ok(action::execute_action(&match_result, &context, &event))
+        Some(eval_result) => {
+            for log_result in &eval_result.log_results {
+                action::execute_action(log_result, &eval_result.context, &event);
+            }
+            match eval_result.terminal_result {
+                Some(ref terminal_result) => Ok(action::execute_action(
+                    terminal_result,
+                    &eval_result.context,
+                    &event,
+                )),
+                None => Ok(output::no_match_output()),
+            }
         }
         None => Ok(output::no_match_output()),
     }


### PR DESCRIPTION
## Summary

- Log actions no longer skip evaluation of subsequent rules
- Log actions are accumulated and all executed before terminal action (block/run)
- Terminal actions (block/run) still stop evaluation immediately

## Changes

- `src/rule.rs`: Added `EvaluationResult` struct, modified `evaluate_rules` to continue on log actions
- `src/main.rs`: Updated to handle new `EvaluationResult` type
- `src/context.rs`: Added `Clone` derive
- `tests/integration_tests.rs`: Added 3 new tests for log continuation behavior

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (109 tests)

Closes #29