### PR TITLE
refactor: Clean up unnecessary comments and DRY up test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +54,7 @@ version = "0.5.1"
 dependencies = [
  "chrono",
  "regex-lite",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",
@@ -122,10 +132,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -134,6 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -151,6 +179,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -292,6 +326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,10 +368,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -369,6 +486,12 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -504,8 +627,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -518,6 +641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +658,28 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ shellish_parse = "2.2"
 [dev-dependencies]
 serial_test = "3.3.1"
 tempfile = "3"
+rstest = "0.24"
 
 [profile.release]
 strip = true

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -277,7 +277,6 @@ fn matches_command(patterns: &[Regex], command: &str) -> bool {
         return true;
     }
 
-    // 複合コマンドを分割
     let commands = crate::parser::split_compound_command(command);
     let command_strings = crate::parser::commands_to_strings(&commands);
 
@@ -315,7 +314,6 @@ fn matches_executable(executables: &[String], command: &str) -> bool {
         return true;
     }
 
-    // コマンドを分割して各コマンド名を取得
     let commands = crate::parser::split_compound_command(command);
     for cmd_tokens in &commands {
         if let Some(cmd_name) = cmd_tokens.first()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
+use rstest::rstest;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -217,64 +218,49 @@ fn test_config_not_found() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("Warning"));
 }
 
-#[test]
-fn test_invalid_regex_pattern() {
-    let input = r#"{"tool_name": "Bash", "tool_input": {"command": "test"}}"#;
-    let config = r#"
+/// Parameterized tests for invalid configuration handling
+#[rstest]
+#[case::invalid_regex(
+    r#"
 [rules.invalid-regex]
 event = "PreToolUse"
 matcher = "[invalid(regex"
 action = "block"
 message = "should not reach"
-"#;
-
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input, config);
-
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("[cchooked]") || stderr.contains("error") || stderr.contains("regex"));
-}
-
-#[test]
-fn test_invalid_event_type() {
-    let input = r#"{"tool_name": "Bash", "tool_input": {"command": "test"}}"#;
-    let config = r#"
+"#,
+    &["[cchooked]", "error", "regex"]
+)]
+#[case::invalid_event(
+    r#"
 [rules.invalid-event]
 event = "InvalidEvent"
 matcher = "Bash"
 action = "block"
 message = "should not reach"
-"#;
-
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input, config);
-
-    assert_eq!(exit_code, 2);
-    assert!(
-        stderr.contains("[cchooked]")
-            || stderr.contains("error")
-            || stderr.contains("unknown")
-            || stderr.contains("invalid")
-    );
-}
-
-#[test]
-fn test_invalid_action_type() {
-    let input = r#"{"tool_name": "Bash", "tool_input": {"command": "test"}}"#;
-    let config = r#"
+"#,
+    &["[cchooked]", "error", "unknown", "invalid"]
+)]
+#[case::invalid_action(
+    r#"
 [rules.invalid-action]
 event = "PreToolUse"
 matcher = "Bash"
 action = "invalid_action"
 message = "should not reach"
-"#;
+"#,
+    &["[cchooked]", "error", "unknown", "invalid"]
+)]
+fn test_invalid_config(#[case] config: &str, #[case] expected_stderr_patterns: &[&str]) {
+    let input = r#"{"tool_name": "Bash", "tool_input": {"command": "test"}}"#;
 
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input, config);
 
     assert_eq!(exit_code, 2);
     assert!(
-        stderr.contains("[cchooked]")
-            || stderr.contains("error")
-            || stderr.contains("unknown")
-            || stderr.contains("invalid")
+        expected_stderr_patterns.iter().any(|p| stderr.contains(p)),
+        "stderr should contain one of {:?}, but was: {}",
+        expected_stderr_patterns,
+        stderr
     );
 }
 
@@ -425,8 +411,17 @@ when.command = ".*"
     assert!(stderr.contains("Command failed"));
 }
 
-#[test]
-fn test_when_command_array_or_logic() {
+/// Parameterized tests for command array OR logic
+#[rstest]
+#[case::npm_blocked("npm install express", 2, true)]
+#[case::yarn_blocked("yarn add express", 2, true)]
+#[case::pnpm_blocked("pnpm install express", 2, true)]
+#[case::bun_allowed("bun install express", 0, false)]
+fn test_when_command_array_or_logic(
+    #[case] command: &str,
+    #[case] expected_exit_code: i32,
+    #[case] should_block: bool,
+) {
     let config = r#"
 [rules.no-package-managers]
 event = "PreToolUse"
@@ -436,30 +431,33 @@ message = "use bun instead"
 when.command = ["^npm\\s", "^yarn\\s", "^pnpm\\s"]
 "#;
 
-    let input_npm = r#"{"tool_name": "Bash", "tool_input": {"command": "npm install express"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_npm, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("use bun instead"));
+    let input = format!(
+        r#"{{"tool_name": "Bash", "tool_input": {{"command": "{}"}}}}"#,
+        command
+    );
+    let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", &input, config);
 
-    let input_yarn = r#"{"tool_name": "Bash", "tool_input": {"command": "yarn add express"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_yarn, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("use bun instead"));
-
-    let input_pnpm = r#"{"tool_name": "Bash", "tool_input": {"command": "pnpm install express"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_pnpm, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("use bun instead"));
-
-    let input_bun = r#"{"tool_name": "Bash", "tool_input": {"command": "bun install express"}}"#;
-    let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_bun, config);
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
+    assert_eq!(exit_code, expected_exit_code);
+    if should_block {
+        assert!(stderr.contains("use bun instead"));
+    } else {
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
 }
 
-#[test]
-fn test_when_file_path_array_or_logic() {
+/// Parameterized tests for file_path array OR logic
+#[rstest]
+#[case::env_blocked("/path/to/.env", 2, true)]
+#[case::env_local_blocked("/path/to/.env.local", 2, true)]
+#[case::secret_blocked("/config/.secret", 2, true)]
+#[case::credentials_blocked("/home/user/credentials.json", 2, true)]
+#[case::config_allowed("/path/to/config.json", 0, false)]
+fn test_when_file_path_array_or_logic(
+    #[case] file_path: &str,
+    #[case] expected_exit_code: i32,
+    #[case] should_block: bool,
+) {
     let config = r#"
 [rules.protect-sensitive-files]
 event = "PreToolUse"
@@ -469,34 +467,19 @@ message = "Cannot edit sensitive files"
 when.file_path = [".*\\.env.*", ".*\\.secret.*", ".*/credentials\\.json$"]
 "#;
 
-    let input_env = r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/.env"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_env, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Cannot edit sensitive files"));
+    let input = format!(
+        r#"{{"tool_name": "Write", "tool_input": {{"file_path": "{}"}}}}"#,
+        file_path
+    );
+    let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", &input, config);
 
-    let input_env_local =
-        r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/.env.local"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_env_local, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Cannot edit sensitive files"));
-
-    let input_secret = r#"{"tool_name": "Write", "tool_input": {"file_path": "/config/.secret"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_secret, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Cannot edit sensitive files"));
-
-    let input_creds =
-        r#"{"tool_name": "Write", "tool_input": {"file_path": "/home/user/credentials.json"}}"#;
-    let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_creds, config);
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Cannot edit sensitive files"));
-
-    let input_normal =
-        r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/config.json"}}"#;
-    let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_normal, config);
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
+    assert_eq!(exit_code, expected_exit_code);
+    if should_block {
+        assert!(stderr.contains("Cannot edit sensitive files"));
+    } else {
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
 }
 
 #[test]
@@ -551,8 +534,15 @@ fn run_cchooked_with_branch(
     )
 }
 
-#[test]
-fn test_when_branch_single_pattern() {
+/// Parameterized tests for branch single pattern matching
+#[rstest]
+#[case::main_blocked("main", 2, true)]
+#[case::feature_allowed("feature/test", 0, false)]
+fn test_when_branch_single_pattern(
+    #[case] branch: &str,
+    #[case] expected_exit_code: i32,
+    #[case] should_block: bool,
+) {
     let config = r#"
 [rules.main-only]
 event = "PreToolUse"
@@ -563,19 +553,28 @@ when.branch = "^main$"
 "#;
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
-    let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Blocked on main branch"));
+    let (exit_code, stdout, stderr) = run_cchooked_with_branch("PreToolUse", input, config, branch);
 
-    let (exit_code, stdout, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "feature/test");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
+    assert_eq!(exit_code, expected_exit_code);
+    if should_block {
+        assert!(stderr.contains("Blocked on main branch"));
+    } else {
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
 }
 
-#[test]
-fn test_when_branch_array_or_logic() {
+/// Parameterized tests for branch array OR logic
+#[rstest]
+#[case::main_blocked("main", 2, true)]
+#[case::master_blocked("master", 2, true)]
+#[case::release_blocked("release/v1.0", 2, true)]
+#[case::feature_allowed("feature/new-feature", 0, false)]
+fn test_when_branch_array_or_logic(
+    #[case] branch: &str,
+    #[case] expected_exit_code: i32,
+    #[case] should_block: bool,
+) {
     let config = r#"
 [rules.protected-branches]
 event = "PreToolUse"
@@ -586,29 +585,28 @@ when.branch = ["^main$", "^master$", "^release/.*"]
 "#;
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
+    let (exit_code, stdout, stderr) = run_cchooked_with_branch("PreToolUse", input, config, branch);
 
-    let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Blocked on protected branches"));
-
-    let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "master");
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Blocked on protected branches"));
-
-    let (exit_code, _, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "release/v1.0");
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Blocked on protected branches"));
-
-    let (exit_code, stdout, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "feature/new-feature");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
+    assert_eq!(exit_code, expected_exit_code);
+    if should_block {
+        assert!(stderr.contains("Blocked on protected branches"));
+    } else {
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
 }
 
-#[test]
-fn test_when_branch_no_match() {
+/// Parameterized tests for branch no match scenarios
+#[rstest]
+#[case::main_allowed("main", 0, false)]
+#[case::develop_allowed("develop", 0, false)]
+#[case::hotfix_allowed("hotfix/urgent-fix", 0, false)]
+#[case::feature_blocked("feature/new-feature", 2, true)]
+fn test_when_branch_no_match(
+    #[case] branch: &str,
+    #[case] expected_exit_code: i32,
+    #[case] should_block: bool,
+) {
     let config = r#"
 [rules.feature-only]
 event = "PreToolUse"
@@ -619,28 +617,15 @@ when.branch = "^feature/.*"
 "#;
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
+    let (exit_code, stdout, stderr) = run_cchooked_with_branch("PreToolUse", input, config, branch);
 
-    let (exit_code, stdout, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
-
-    let (exit_code, stdout, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "develop");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
-
-    let (exit_code, stdout, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "hotfix/urgent-fix");
-    assert_eq!(exit_code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
-
-    let (exit_code, _, stderr) =
-        run_cchooked_with_branch("PreToolUse", input, config, "feature/new-feature");
-    assert_eq!(exit_code, 2);
-    assert!(stderr.contains("Blocked on feature branches"));
+    assert_eq!(exit_code, expected_exit_code);
+    if should_block {
+        assert!(stderr.contains("Blocked on feature branches"));
+    } else {
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
 }
 
 // =============================================================================

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -339,9 +339,8 @@ log_file = "{}"
 
     assert_eq!(exit_code, 0);
     assert!(stdout.is_empty());
-    assert!(stderr.is_empty()); // ファイル出力時はstderrは空
+    assert!(stderr.is_empty());
 
-    // ファイルの内容を確認
     let log_content = fs::read_to_string(&log_file_path).unwrap();
     assert!(log_content.contains(r#""event":"PreToolUse""#));
     assert!(log_content.contains(r#""tool":"Bash""#));
@@ -371,9 +370,8 @@ log_file = "{}"
 
     assert_eq!(exit_code, 0);
     assert!(stdout.is_empty());
-    assert!(stderr.is_empty()); // ファイル出力時はstderrは空
+    assert!(stderr.is_empty());
 
-    // ファイルの内容を確認
     let log_content = fs::read_to_string(&log_file_path).unwrap();
     assert!(log_content.contains("PreToolUse"));
     assert!(log_content.contains("Write"));
@@ -450,25 +448,21 @@ message = "use bun instead"
 when.command = ["^npm\\s", "^yarn\\s", "^pnpm\\s"]
 "#;
 
-    // npm にマッチ
     let input_npm = r#"{"tool_name": "Bash", "tool_input": {"command": "npm install express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_npm, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("use bun instead"));
 
-    // yarn にマッチ
     let input_yarn = r#"{"tool_name": "Bash", "tool_input": {"command": "yarn add express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_yarn, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("use bun instead"));
 
-    // pnpm にマッチ
     let input_pnpm = r#"{"tool_name": "Bash", "tool_input": {"command": "pnpm install express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_pnpm, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("use bun instead"));
 
-    // bun はマッチしない
     let input_bun = r#"{"tool_name": "Bash", "tool_input": {"command": "bun install express"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_bun, config);
     assert_eq!(exit_code, 0);
@@ -487,33 +481,28 @@ message = "Cannot edit sensitive files"
 when.file_path = [".*\\.env.*", ".*\\.secret.*", ".*/credentials\\.json$"]
 "#;
 
-    // .env にマッチ
     let input_env = r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/.env"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_env, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Cannot edit sensitive files"));
 
-    // .env.local にマッチ
     let input_env_local =
         r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/.env.local"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_env_local, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Cannot edit sensitive files"));
 
-    // .secret にマッチ
     let input_secret = r#"{"tool_name": "Write", "tool_input": {"file_path": "/config/.secret"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_secret, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Cannot edit sensitive files"));
 
-    // credentials.json にマッチ
     let input_creds =
         r#"{"tool_name": "Write", "tool_input": {"file_path": "/home/user/credentials.json"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_creds, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Cannot edit sensitive files"));
 
-    // 通常のファイルはマッチしない
     let input_normal =
         r#"{"tool_name": "Write", "tool_input": {"file_path": "/path/to/config.json"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_normal, config);
@@ -607,13 +596,11 @@ message = "Blocked on main branch"
 when.branch = "^main$"
 "#;
 
-    // main ブランチでマッチ
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
     let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Blocked on main branch"));
 
-    // feature ブランチではマッチしない
     let (exit_code, stdout, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "feature/test");
     assert_eq!(exit_code, 0);
@@ -634,23 +621,19 @@ when.branch = ["^main$", "^master$", "^release/.*"]
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
 
-    // main にマッチ
     let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Blocked on protected branches"));
 
-    // master にマッチ
     let (exit_code, _, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "master");
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Blocked on protected branches"));
 
-    // release/v1.0 にマッチ
     let (exit_code, _, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "release/v1.0");
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Blocked on protected branches"));
 
-    // feature ブランチはマッチしない
     let (exit_code, stdout, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "feature/new-feature");
     assert_eq!(exit_code, 0);
@@ -671,27 +654,23 @@ when.branch = "^feature/.*"
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "echo test"}}"#;
 
-    // main はマッチしない
     let (exit_code, stdout, stderr) = run_cchooked_with_branch("PreToolUse", input, config, "main");
     assert_eq!(exit_code, 0);
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // develop はマッチしない
     let (exit_code, stdout, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "develop");
     assert_eq!(exit_code, 0);
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // hotfix/xxx はマッチしない
     let (exit_code, stdout, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "hotfix/urgent-fix");
     assert_eq!(exit_code, 0);
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // feature/xxx はマッチする
     let (exit_code, _, stderr) =
         run_cchooked_with_branch("PreToolUse", input, config, "feature/new-feature");
     assert_eq!(exit_code, 2);
@@ -1125,13 +1104,11 @@ message = "Use bun instead of npm"
 when.executable = "npm"
 "#;
 
-    // npm コマンドはブロックされる
     let input_npm = r#"{"tool_name": "Bash", "tool_input": {"command": "npm install express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_npm, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Use bun instead of npm"));
 
-    // bun コマンドはブロックされない
     let input_bun = r#"{"tool_name": "Bash", "tool_input": {"command": "bun install express"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_bun, config);
     assert_eq!(exit_code, 0);
@@ -1150,25 +1127,21 @@ message = "Use bun instead"
 when.executable = ["npm", "yarn", "pnpm"]
 "#;
 
-    // npm にマッチ
     let input_npm = r#"{"tool_name": "Bash", "tool_input": {"command": "npm install express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_npm, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Use bun instead"));
 
-    // yarn にマッチ
     let input_yarn = r#"{"tool_name": "Bash", "tool_input": {"command": "yarn add express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_yarn, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Use bun instead"));
 
-    // pnpm にマッチ
     let input_pnpm = r#"{"tool_name": "Bash", "tool_input": {"command": "pnpm install express"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_pnpm, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Use bun instead"));
 
-    // bun はマッチしない
     let input_bun = r#"{"tool_name": "Bash", "tool_input": {"command": "bun install express"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_bun, config);
     assert_eq!(exit_code, 0);
@@ -1200,7 +1173,6 @@ when.executable = "npm"
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("npm is not allowed"));
 
-    // npm を含まない複合コマンドはブロックされない
     let input_no_npm = r#"{"tool_name": "Bash", "tool_input": {"command": "echo start && bun install && echo done"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_no_npm, config);
     assert_eq!(exit_code, 0);
@@ -1221,13 +1193,11 @@ when.executable = "git"
 when.command = "--force"
 "#;
 
-    // git push --force はブロックされる
     let input_force = r#"{"tool_name": "Bash", "tool_input": {"command": "git push --force"}}"#;
     let (exit_code, _, stderr) = run_cchooked("PreToolUse", input_force, config);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Force push is not allowed"));
 
-    // git push (--force なし) はブロックされない
     let input_no_force =
         r#"{"tool_name": "Bash", "tool_input": {"command": "git push origin main"}}"#;
     let (exit_code, stdout, stderr) = run_cchooked("PreToolUse", input_no_force, config);
@@ -1273,7 +1243,6 @@ fn test_config_parse_error_returns_exit_code_2() {
     let temp_dir = TempDir::new().unwrap();
     let config_dir = temp_dir.path().join(".claude");
     fs::create_dir_all(&config_dir).unwrap();
-    // Invalid TOML syntax
     fs::write(config_dir.join("hooks-rules.toml"), "invalid [ toml syntax").unwrap();
 
     let input = r#"{"tool_name": "Bash", "tool_input": {"command": "test"}}"#;


### PR DESCRIPTION
## Summary

- Remove comments that merely restate what the code already expresses
- Extract common logic in `run_cchooked` functions into `run_cchooked_internal`
- Parameterize repetitive tests using `rstest` crate

## Changes

### 1. Remove unnecessary comments
- `src/rule.rs`: 2 comments removed
- `tests/integration_tests.rs`: 31 comments removed

### 2. Extract common logic in run_cchooked functions
- Introduce `run_cchooked_internal` to consolidate duplicated code
- `run_cchooked`, `run_cchooked_with_dir`, `run_cchooked_with_branch` now delegate to internal function

### 3. Parameterize tests with rstest
- Add `rstest` dev-dependency
- Consolidate config error tests (3 cases)
- Parameterize command array OR logic tests (4 cases)
- Parameterize file_path array OR logic tests (5 cases)
- Parameterize branch condition tests (10 cases)

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (123 tests)